### PR TITLE
increase spacing between bio and photo on mobile page

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -195,7 +195,7 @@ body::after {
   }
 
   .about-shell {
-    @apply max-w-5xl items-center gap-10 space-y-0 md:flex md:justify-between;
+    @apply max-w-5xl items-center gap-10 space-y-8 md:flex md:justify-between md:space-y-0;
   }
 
   .about-copy {


### PR DESCRIPTION
- Increased mobile-only vertical spacing in the About section so the profile photo is no longer crowded against the bio text.
- Updated `.about-shell` in `src/styles/global.css` to `space-y-8` on mobile while preserving desktop layout with `md:space-y-0`; build verified with `npm run build`.